### PR TITLE
Specified compatible PHP version

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -8,6 +8,7 @@ If you have OXID eShop version 6.2 or higher, install :productname:`PayPal Check
 |prerequisites|
 
 * You have installed OXID eShop 6.1.
+* Your environment is running PHP 7.1.
 * You have configured `https`.
 
    a. In the :file:`<root directory of the eShop>/source` directory, open the :file:`config.inc.php` file.


### PR DESCRIPTION
PayPal Checkout 1 is said to be compatible with OXID eShop 6.1.

The shop needs PHP 7.0 or 7.1:
https://docs.oxid-esales.com/eshop/de/6.1/installation/neu-installation/server-und-systemvoraussetzungen.html#php

The module on the other hands has requirement `"oxid-solution-catalysts/paypal-client": "^v1.0"`.
https://github.com/OXID-eSales/paypal-module/blob/a4653d5dfc9d925acceb5b1a867ab8ec9009108d/composer.json#L33

which requires at least PHP 7.1:
https://github.com/OXID-eSales/paypal-client/blob/d6a9b2d3242d1d0552e598c1022554ad38858ec4/composer.json#L6

Therefore the docs need to be adapted to inform the user before installation.

just fyI:
The information is not needed for PayPal Checkout 2, since you need OXID eShop 6.2 or above, which requires PHP 7.1 or above anyway.